### PR TITLE
Fix urlpatterns use Sequence instead of List

### DIFF
--- a/rest_framework-stubs/urlpatterns.pyi
+++ b/rest_framework-stubs/urlpatterns.pyi
@@ -1,15 +1,15 @@
-from typing import List, Optional, Pattern, Union
+from typing import List, Optional, Pattern, Sequence, Union
 
 from django.urls.resolvers import RoutePattern, URLPattern, URLResolver
 
 def apply_suffix_patterns(
-    urlpatterns: List[Union[URLResolver, RoutePattern, URLPattern, Pattern[str]]],
+    urlpatterns: Sequence[Union[URLResolver, RoutePattern, URLPattern, Pattern[str]]],
     suffix_pattern: Union[str, Pattern[str]],
     suffix_required: bool,
     suffix_route: Optional[str] = ...,
 ) -> List[URLPattern]: ...
 def format_suffix_patterns(
-    urlpatterns: List[Union[URLResolver, RoutePattern, URLPattern, Pattern[str]]],
+    urlpatterns: Sequence[Union[URLResolver, RoutePattern, URLPattern, Pattern[str]]],
     suffix_required: bool = ...,
     allowed: Optional[List[Union[URLPattern, Pattern[str], str]]] = ...,
 ) -> List[URLPattern]: ...


### PR DESCRIPTION
Use `Sequence` instead of `List` in `apply_suffix_patterns` and `format_suffix_patterns`. This thread, https://github.com/python/mypy/issues/3351#issuecomment-300447832, explains why `List`, which is invariant, isn't suitable here