### PR TITLE
Add `client` type in test cases

### DIFF
--- a/rest_framework-stubs/test.pyi
+++ b/rest_framework-stubs/test.pyi
@@ -209,10 +209,8 @@ class APISimpleTestCase(testcases.SimpleTestCase):
     client_class: APIClient = ...
     client: APIClient
 
-
 class APILiveServerTestCase(testcases.LiveServerTestCase):
     client_class: APIClient = ...
     client: APIClient
-
 
 class URLPatternsTestCase(testcases.SimpleTestCase): ...

--- a/rest_framework-stubs/test.pyi
+++ b/rest_framework-stubs/test.pyi
@@ -199,14 +199,20 @@ class APIClient(APIRequestFactory, DjangoClient):
 
 class APITransactionTestCase(testcases.TransactionTestCase):
     client_class: APIClient = ...
+    client: APIClient
 
 class APITestCase(testcases.TestCase):
     client_class: APIClient = ...
+    client: APIClient
 
 class APISimpleTestCase(testcases.SimpleTestCase):
     client_class: APIClient = ...
+    client: APIClient
+
 
 class APILiveServerTestCase(testcases.LiveServerTestCase):
     client_class: APIClient = ...
+    client: APIClient
+
 
 class URLPatternsTestCase(testcases.SimpleTestCase): ...


### PR DESCRIPTION
Currently, when using `APITestCase`, `self.client` is inferred as `Client`, derived from Django's `TestCase`. This results in errors like:

``` 
Cannot access member "force_authenticate" for type "Client"
  Member "force_authenticate" is unknown
```

Adding `client: APIClient` to the test cases fixes this error.