### PR TITLE
Improve `Response.data` typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "djangorestframework-types"
-version = "0.7.1"
+version = "0.8.1"
 description = "Type stubs for Django Rest Framework"
 authors = ["Steve Dignam <steve@dignam.xyz>"]
 repository = "https://github.com/sbdchd/djangorestframework-types"

--- a/rest_framework-stubs/response.pyi
+++ b/rest_framework-stubs/response.pyi
@@ -3,7 +3,7 @@ from typing import Any, Dict, Mapping, Optional
 from django.template.response import SimpleTemplateResponse
 
 class Response(SimpleTemplateResponse):
-    data: object
+    data: dict[str, Any] | list
     exception: bool = ...
     content_type: Optional[str] = ...
     _headers: Dict[str, tuple[str, str]]


### PR DESCRIPTION
The `data` attribute from `Response` was set to be `Any`. However, it should be a dict with type `dict[str, Any]`. 


This patch fixes this. The version was bumped from 0.7.1 to 0.8.1. 0.8.0 appears to be missing from the repo, but it is present on pypi for some reason.