### PR TITLE
fix(serializers): BaseSerializer should return Self

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -646,13 +646,13 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.0.1"
-description = "Backported and Experimental Type Hints for Python 3.6+"
+version = "4.7.1"
+description = "Backported and Experimental Type Hints for Python 3.7+"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "typing_extensions-4.0.1-py3-none-any.whl", hash = "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"},
-    {file = "typing_extensions-4.0.1.tar.gz", hash = "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e"},
+    {file = "typing_extensions-4.7.1-py3-none-any.whl", hash = "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36"},
+    {file = "typing_extensions-4.7.1.tar.gz", hash = "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"},
 ]
 
 [[package]]
@@ -684,4 +684,4 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "36f91b64ad0604b65d3bde71d10711c40a114ac33b200cc28361ab712dadfe22"
+content-hash = "b1288f17c7cc0341c7b7355f604f6c53a724ded5729b28d2f49ae925077e8230"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
+typing_extensions = { version = "^4.6", python = "<3.11" }
 
 [tool.poetry.dev-dependencies]
 ipython = "^7.19"

--- a/rest_framework-stubs/serializers.pyi
+++ b/rest_framework-stubs/serializers.pyi
@@ -11,6 +11,7 @@ from typing import (
     Literal,
     NoReturn,
 )
+from typing_extensions import Self
 
 from django.db import models
 from django.db.models import Manager, QuerySet
@@ -82,7 +83,7 @@ class BaseSerializer(Field[Any, Any, Any, Any]):
     instance: Any | None
     initial_data: Any
     _context: dict[str, Any]
-    def __new__(cls, *args: Any, **kwargs: Any) -> BaseSerializer: ...
+    def __new__(cls, *args: Any, **kwargs: Any) -> Self: ...
     def __class_getitem__(cls, *args: Any, **kwargs: Any) -> Any: ...
     def __init__(
         self,


### PR DESCRIPTION
This fixes invalid type in following code:

```python
    def factory(
        serializer: Type[ModelSerializer],
        data: Dict[str, str],
    ) -> ModelSerializer:
        return serializer(data=data)
```

Without Self returned type is "BaseSerializer".